### PR TITLE
feat: add faiss fallback for cross-platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ accelerate==0.33.0
 torch==2.2.2
 fastembed==0.3.5
 flashrank==0.2.7
-faiss-cpu==1.8.0.post1
+faiss-cpu==1.8.0.post1; platform_system == "Linux"
 spacy==3.7.4
 python-dateutil==2.9.0.post0
 sentencepiece==0.2.0

--- a/run.py
+++ b/run.py
@@ -86,6 +86,9 @@ def wait_until_ready(timeout_sec=900):
         if j and j.get("status") == "ready":
             return True
         state = j.get("status") if isinstance(j, dict) else "down"
+        if state == "error":
+            log(f"Backend status: error ({j.get('error')}) …")
+            return False
         log(f"Backend status: {state} …")
         time.sleep(2.0)
     return False

--- a/tg_graphrag.py
+++ b/tg_graphrag.py
@@ -8,7 +8,10 @@ from dataclasses import dataclass, field
 import numpy as np
 
 import psutil
-import faiss
+try:
+    import faiss  # optional high-performance vector search
+except Exception:  # pragma: no cover - faiss may not be available on all platforms
+    faiss = None
 import torch
 import spacy
 from tqdm import tqdm
@@ -23,6 +26,7 @@ from graph_store import GraphStore
 IDX_DIR = "indexes"
 MAP_PATH = os.path.join(IDX_DIR, "chunks.jsonl")
 FAISS_PATH = os.path.join(IDX_DIR, "faiss.index")
+NPY_PATH = os.path.join(IDX_DIR, "vectors.npy")
 
 os.makedirs(IDX_DIR, exist_ok=True)
 
@@ -48,9 +52,13 @@ class GraphRAG:
         # Embeddings
         self.embedder = TextEmbedding()
         self.dim = self._infer_embed_dim()
-        self.index = faiss.IndexFlatIP(self.dim)
         self.chunks: List[Chunk] = []
         self.lock = threading.Lock()
+        self.vecs: List[np.ndarray] = []  # fallback vectors if faiss unavailable
+        if faiss is not None:
+            self.index = faiss.IndexFlatIP(self.dim)
+        else:
+            self.index = None
 
         # Reranker
         self.reranker = Ranker()
@@ -138,14 +146,23 @@ class GraphRAG:
 
     # ---------------------- Persistence ----------------------
     def _load(self):
-        if os.path.exists(FAISS_PATH) and os.path.exists(MAP_PATH):
-            self.index = faiss.read_index(FAISS_PATH)
+        if os.path.exists(MAP_PATH):
             with open(MAP_PATH, "r", encoding="utf-8") as f:
                 for line in f:
                     self.chunks.append(Chunk(**json.loads(line)))
+        if faiss is not None and os.path.exists(FAISS_PATH):
+            self.index = faiss.read_index(FAISS_PATH)
+        elif os.path.exists(NPY_PATH):
+            try:
+                self.vecs = np.load(NPY_PATH).tolist()
+            except Exception:
+                self.vecs = []
 
     def _save(self):
-        faiss.write_index(self.index, FAISS_PATH)
+        if self.index is not None and faiss is not None:
+            faiss.write_index(self.index, FAISS_PATH)
+        else:
+            np.save(NPY_PATH, np.array(self.vecs, dtype="float32"))
         with open(MAP_PATH, "w", encoding="utf-8") as f:
             for c in self.chunks:
                 f.write(json.dumps(c.__dict__) + "\n")
@@ -198,10 +215,17 @@ class GraphRAG:
         # embed
         vectors = np.array(
             [v for v in self.embedder.embed(texts)], dtype="float32")
-        faiss.normalize_L2(vectors)
+        if self.index is not None and faiss is not None:
+            faiss.normalize_L2(vectors)
+        else:
+            norms = np.linalg.norm(vectors, axis=1, keepdims=True) + 1e-12
+            vectors = vectors / norms
 
         with self.lock:
-            self.index.add(vectors)
+            if self.index is not None and faiss is not None:
+                self.index.add(vectors)
+            else:
+                self.vecs.extend(vectors)
             for m in metas:
                 ch = Chunk(**m)
                 self.chunks.append(ch)
@@ -216,10 +240,19 @@ class GraphRAG:
         # embed query
         qvec = np.array(
             [v for v in self.embedder.embed([query])], dtype="float32")
-        faiss.normalize_L2(qvec)
-        scores, idxs = self.index.search(qvec, max(k*3, k))
-        idxs = idxs[0]
-        scs = scores[0]
+        if self.index is not None and faiss is not None:
+            faiss.normalize_L2(qvec)
+            scores, idxs = self.index.search(qvec, max(k*3, k))
+            idxs = idxs[0]
+            scs = scores[0]
+        else:
+            qvec /= (np.linalg.norm(qvec, axis=1, keepdims=True) + 1e-12)
+            if not self.vecs:
+                return [], []
+            mat = np.array(self.vecs)
+            scs = mat @ qvec[0]
+            idxs = np.argsort(-scs)[:max(k*3, k)]
+            scs = scs[idxs]
         base = []
         for i, s in zip(idxs, scs):
             if i < 0:
@@ -287,9 +320,20 @@ class GraphRAG:
         for q2 in expansions:
             qvec = np.array(
                 [v for v in self.embedder.embed([q2])], dtype="float32")
-            faiss.normalize_L2(qvec)
-            scores, idxs = self.index.search(qvec, k)
-            for i, s in zip(idxs[0], scores[0]):
+            if self.index is not None and faiss is not None:
+                faiss.normalize_L2(qvec)
+                scores, idxs = self.index.search(qvec, k)
+                iter_pairs = zip(idxs[0], scores[0])
+            else:
+                qvec /= (np.linalg.norm(qvec, axis=1, keepdims=True) + 1e-12)
+                if not self.vecs:
+                    iter_pairs = []
+                else:
+                    mat = np.array(self.vecs)
+                    scs = mat @ qvec[0]
+                    idxs = np.argsort(-scs)[:k]
+                    iter_pairs = zip(idxs, scs[idxs])
+            for i, s in iter_pairs:
                 if i < 0:
                     continue
                 ch = self.chunks[i]


### PR DESCRIPTION
## Summary
- allow running without faiss, falling back to numpy vectors on platforms where faiss isn't available
- conditionally install faiss only on Linux
- surface backend error message during startup

## Testing
- `python -m py_compile tg_graphrag.py server.py run.py`
- `python run.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adbdb00f608320b439e911d878547b